### PR TITLE
Data processing and storage are separated

### DIFF
--- a/src/Entities/Make/InitDataMake.php
+++ b/src/Entities/Make/InitDataMake.php
@@ -6,18 +6,18 @@ use TgWebValid\Entities\InitData\Chat;
 use TgWebValid\Entities\InitData\Receiver;
 use TgWebValid\Entities\InitData\User;
 
-class InitDataMake extends Make
+abstract class InitDataMake extends Make
 {
     public function __construct(array $props)
     {
         foreach ($props as $prop => $value) {
-            $props[$prop] = match ($prop) {
+            $value = match ($prop) {
                 'user'     => new User(json_decode($value, true)),
                 'receiver' => new Receiver(json_decode($value, true)),
                 'chat'     => new Chat(json_decode($value, true)),
                 default    => $value
             };
+            $this->setProperty(camelize($prop), $value);
         }
-        parent::__construct($props);
     }
 }

--- a/src/Entities/Make/Make.php
+++ b/src/Entities/Make/Make.php
@@ -2,18 +2,19 @@
 
 namespace TgWebValid\Entities\Make;
 
-class Make
+abstract class Make
 {
     public function __construct(array $props)
     {
-        $getClass = get_class($this);
-
         foreach ($props as $prop => $value) {
-            $prop = camelize($prop);
-            if (!property_exists($getClass, $prop)) {
-                continue;
-            }
-            $this->$prop = $value;
+            $this->setProperty(camelize($prop), $value);
+        }
+    }
+
+    protected function setProperty(string $property, mixed $value): void
+    {
+        if (property_exists(get_class($this), $property)) {
+            $this->$property = $value;
         }
     }
 }


### PR DESCRIPTION
Using Make just got easier. You can inherit from the Make base class and rework the class constructor to suit the needs of each entity. In this case, there is no need to call the parent constructor. Thus, the double loop is eliminated, and the speed is improved.

To populate an entity with data, you need to call the parent's `setProperty` method, passing the necessary arguments. It will do the rest for you. Also, all Make classes are declared abstract because there's no point in calling them without an entity.