### PR TITLE
Extract hash calculation to separate functions

### DIFF
--- a/src/Validator/InitDataValidator.php
+++ b/src/Validator/InitDataValidator.php
@@ -15,7 +15,7 @@ class InitDataValidator extends Validator
         $rawData = $this->sortData($rawData);
         $rawData = $this->ridHash($rawData);
         $data    = $this->implodeData($rawData);
-        $hash    = $this->calculateHash($data);
+        $hash    = hashInitData($data, $this->token);
 
         if (0 === strcmp($hash, $initData->hash)) {
             return $initData;
@@ -35,11 +35,5 @@ class InitDataValidator extends Validator
             },
             $rawData
         ));
-    }
-
-    private function calculateHash(string $data): string
-    {
-        $secretKey = hash_hmac('sha256', $this->token, 'WebAppData', true);
-        return bin2hex(hash_hmac('sha256', $data, $secretKey, true));
     }
 }

--- a/src/Validator/LoginWidgetValidator.php
+++ b/src/Validator/LoginWidgetValidator.php
@@ -14,18 +14,12 @@ class LoginWidgetValidator extends Validator
         $rawData = $this->sortData($rawData);
         $rawData = $this->ridHash($rawData);
         $data    = $this->implodeData($rawData);
-        $hash    = $this->calculateHash($data);
+        $hash    = hashLoginWidget($data, $this->token);
 
         if (0 === strcmp($hash, $user->hash)) {
             return $user;
         }
 
         return false;
-    }
-
-    private function calculateHash(string $data): string
-    {
-        $secretKey = hash('sha256', $this->token, true);
-        return hash_hmac('sha256', $data, $secretKey);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -12,3 +12,34 @@ if (!function_exists('camelize')) {
         return lcfirst(str_replace('_', '', mb_convert_case($str, MB_CASE_TITLE, 'UTF-8')));
     }
 }
+
+if (!function_exists('hashLoginWidget')) {
+    /**
+     * Calculates hash for LoginWidget using the specified token and data.
+     *
+    * @param string $data The data to calculate the hash for.
+    * @param string $token The token used for hashing.
+    * @return string The calculated hash.
+     */
+    function hashLoginWidget(string $data, string $token): string
+    {
+        $secretKey = hash('sha256', $token, true);
+        return hash_hmac('sha256', $data, $secretKey);
+    }
+}
+
+
+if (!function_exists('hashInitData')) {
+    /**
+     * Calculates hash for InitData using the specified token and data.
+     *
+    * @param string $data The data to calculate the hash for.
+    * @param string $token The token used for hashing.
+    * @return string The calculated hash.
+     */
+    function hashInitData(string $data, string $token): string
+    {
+        $secretKey = hash_hmac('sha256', $token, 'WebAppData', true);
+        return bin2hex(hash_hmac('sha256', $data, $secretKey, true));
+    }
+}


### PR DESCRIPTION
This refactoring improves code modularity and allows the hash calculation to be used independently without the need for an instance of the class. These changes facilitate easier testing and usage of the hash calculation functions in different contexts.