### PR TITLE
Add the ability to get data as an array (#37)

### DIFF
--- a/src/Make/Make.php
+++ b/src/Make/Make.php
@@ -2,7 +2,9 @@
 
 namespace TgWebValid\Make;
 
-abstract class Make
+use TgWebValid\Support\Arrayable;
+
+abstract class Make extends Arrayable
 {
     /**
      * @param array<string, int|string|bool> $props

--- a/src/Support/Arrayable.php
+++ b/src/Support/Arrayable.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace TgWebValid\Support;
+
+use ReflectionClass;
+use ReflectionProperty;
+
+abstract class Arrayable
+{
+    /**
+     * Converts the object or its properties to an array recursively.
+     *
+     * @param ?object $object The object to convert to an array. If null, the current object is used.
+     * @return array<string, mixed> The array representation of the object or its properties.
+     */
+    public function toArray(?object $object = null): array
+    {
+        $object = $object ?? $this;
+
+        $reflection = new ReflectionClass($object);
+        $properties = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
+
+        $result = [];
+
+        foreach ($properties as $property) {
+            $name = $property->getName();
+            $value = $object->$name ?? null;
+            $result[$name] = match(true) {
+                is_object($value) => $this->toArray($value),
+                is_array($value) => array_map(function($item) {
+                    return is_object($item)
+                        ? $this->toArray($item)
+                        : $item;
+                }, $value),
+                default => $value
+            };
+        }
+
+        return $result;
+    }
+}

--- a/tests/Entities/InitData/ChatTest.php
+++ b/tests/Entities/InitData/ChatTest.php
@@ -4,6 +4,7 @@ namespace TgWebValid\Test\Entities\InitData;
 
 use PHPUnit\Framework\TestCase;
 use TgWebValid\Entities\InitData\Chat;
+use TgWebValid\Support\Arrayable;
 
 final class ChatTest extends TestCase
 {
@@ -25,6 +26,7 @@ final class ChatTest extends TestCase
         $this->assertEquals($data['title'], $chat->title);
         $this->assertNull($chat->username);
         $this->assertNull($chat->photoUrl);
+        $this->assertInstanceOf(Arrayable::class, $chat);
 
         return $data;
     }
@@ -42,5 +44,6 @@ final class ChatTest extends TestCase
 
         $this->assertEquals($data['username'], $chat->username);
         $this->assertEquals($data['photo_url'], $chat->photoUrl);
+        $this->assertInstanceOf(Arrayable::class, $chat);
     }
 }

--- a/tests/Entities/InitData/ReceiverTest.php
+++ b/tests/Entities/InitData/ReceiverTest.php
@@ -4,6 +4,7 @@ namespace TgWebValid\Test\Entities\InitData;
 
 use PHPUnit\Framework\TestCase;
 use TgWebValid\Entities\InitData\Receiver;
+use TgWebValid\Support\Arrayable;
 
 final class ReceiverTest extends TestCase
 {
@@ -26,6 +27,7 @@ final class ReceiverTest extends TestCase
         $this->assertNull($receiver->username);
         $this->assertNull($receiver->isPremium);
         $this->assertNull($receiver->photoUrl);
+        $this->assertInstanceOf(Arrayable::class, $receiver);
 
         return $data;
     }
@@ -49,5 +51,6 @@ final class ReceiverTest extends TestCase
         $this->assertEquals($data['username'], $receiver->username);
         $this->assertTrue($receiver->isPremium);
         $this->assertEquals($data['photo_url'], $receiver->photoUrl);
+        $this->assertInstanceOf(Arrayable::class, $receiver);
     }
 }

--- a/tests/Entities/InitData/ReceiverTest.php
+++ b/tests/Entities/InitData/ReceiverTest.php
@@ -21,6 +21,11 @@ final class ReceiverTest extends TestCase
 
         $this->assertEquals($data['id'], $receiver->id);
         $this->assertEquals($data['first_name'], $receiver->firstName);
+        $this->assertNull($receiver->isBot);
+        $this->assertNull($receiver->lastName);
+        $this->assertNull($receiver->username);
+        $this->assertNull($receiver->isPremium);
+        $this->assertNull($receiver->photoUrl);
 
         return $data;
     }

--- a/tests/Entities/InitData/UserTest.php
+++ b/tests/Entities/InitData/UserTest.php
@@ -4,6 +4,7 @@ namespace TgWebValid\Test\Entities\InitData;
 
 use PHPUnit\Framework\TestCase;
 use TgWebValid\Entities\InitData\User;
+use TgWebValid\Support\Arrayable;
 
 final class UserTest extends TestCase
 {
@@ -27,6 +28,7 @@ final class UserTest extends TestCase
         $this->assertNull($user->languageCode);
         $this->assertNull($user->isPremium);
         $this->assertNull($user->photoUrl);
+        $this->assertInstanceOf(Arrayable::class, $user);
 
         return $data;
     }
@@ -52,5 +54,6 @@ final class UserTest extends TestCase
         $this->assertEquals($data['language_code'], $user->languageCode);
         $this->assertFalse($user->isPremium);
         $this->assertEquals($data['photo_url'], $user->photoUrl);
+        $this->assertInstanceOf(Arrayable::class, $user);
     }
 }

--- a/tests/Entities/InitDataTest.php
+++ b/tests/Entities/InitDataTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use TgWebValid\Entities\InitData\Chat;
 use TgWebValid\Entities\InitData\Receiver;
 use TgWebValid\Entities\InitData\User;
+use TgWebValid\Support\Arrayable;
 
 final class InitDataTest extends TestCase
 {
@@ -29,6 +30,7 @@ final class InitDataTest extends TestCase
         $this->assertNull($initData->queryId);
         $this->assertNull($initData->startParam);
         $this->assertNull($initData->canSendAfter);
+        $this->assertInstanceOf(Arrayable::class, $initData);
 
         return $data;
     }
@@ -44,6 +46,7 @@ final class InitDataTest extends TestCase
         $initData = new InitData($data);
 
         $this->assertInstanceOf(User::class, $initData->user);
+        $this->assertInstanceOf(Arrayable::class, $initData);
     }
 
     /**
@@ -57,6 +60,7 @@ final class InitDataTest extends TestCase
         $initData = new InitData($data);
 
         $this->assertInstanceOf(Receiver::class, $initData->receiver);
+        $this->assertInstanceOf(Arrayable::class, $initData);
     }
 
     /**
@@ -70,6 +74,7 @@ final class InitDataTest extends TestCase
         $initData = new InitData($data);
 
         $this->assertInstanceOf(Chat::class, $initData->chat);
+        $this->assertInstanceOf(Arrayable::class, $initData);
     }
 
     /**
@@ -87,5 +92,6 @@ final class InitDataTest extends TestCase
         $this->assertEquals($data['query_id'], $initData->queryId);
         $this->assertEquals($data['start_param'], $initData->startParam);
         $this->assertEquals($data['can_send_after'], $initData->canSendAfter);
+        $this->assertInstanceOf(Arrayable::class, $initData);
     }
 }

--- a/tests/Entities/LoginWidgetTest.php
+++ b/tests/Entities/LoginWidgetTest.php
@@ -4,6 +4,7 @@ namespace TgWebValid\Test\Entities;
 
 use PHPUnit\Framework\TestCase;
 use TgWebValid\Entities\LoginWidget;
+use TgWebValid\Support\Arrayable;
 
 final class LoginWidgetTest extends TestCase
 {
@@ -28,6 +29,7 @@ final class LoginWidgetTest extends TestCase
         $this->assertNull($loginWidget->lastName);
         $this->assertNull($loginWidget->photoUrl);
         $this->assertNull($loginWidget->username);
+        $this->assertInstanceOf(Arrayable::class, $loginWidget);
 
         return $data;
     }
@@ -47,5 +49,6 @@ final class LoginWidgetTest extends TestCase
         $this->assertEquals($data['last_name'], $loginWidget->lastName);
         $this->assertEquals($data['photo_url'], $loginWidget->photoUrl);
         $this->assertEquals($data['username'], $loginWidget->username);
+        $this->assertInstanceOf(Arrayable::class, $loginWidget);
     }
 }

--- a/tests/Support/ArrayableTest.php
+++ b/tests/Support/ArrayableTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace TgWebValid\Test\Support;
+
+use PHPUnit\Framework\TestCase;
+use TgWebValid\Support\Arrayable;
+
+final class ArrayableTest extends TestCase
+{
+
+    public function testEmpty(): void
+    {
+        $arrayable = new class extends Arrayable {};
+        $this->assertEmpty($arrayable->toArray());
+    }
+
+    public function testPropertyInitialization(): void
+    {
+        $arrayable = new class extends Arrayable
+        {
+            public int $id;
+            public string $firstName = '';
+            public ?string $lastName;
+            public ?string $username = null;
+            // @phpstan-ignore-next-line
+            public $languageCode = null;
+            public bool $isPremium;
+            // @phpstan-ignore-next-line
+            public $photoUrl;
+        };
+
+        $this->assertEquals([
+            'id' => null,
+            'firstName' => '',
+            'lastName' => null,
+            'username' => null,
+            'languageCode' => null,
+            'isPremium' => null,
+            'photoUrl' => null
+        ], $arrayable->toArray());
+    }
+
+    public function testPropertyAccess(): void
+    {
+        $arrayable = new class extends Arrayable
+        {
+            public int $id;
+            // @phpstan-ignore-next-line
+            protected $firstName;
+            // @phpstan-ignore-next-line
+            private ?string $lastName = null;
+        };
+
+        $this->assertEquals([
+            'id' => null
+        ], $arrayable->toArray());
+    }
+
+    public function testPropertyDeep(): object
+    {
+        $user = new class
+        {
+            public int $id;
+            public string $firstName = 'Сергій';
+        };
+
+        $initData = new class ($user)
+        {
+            public ?string $queryId = null;
+            public function __construct(
+                public object $user
+            )
+            {
+            }
+        };
+
+        $arrayable = new class ($initData) extends Arrayable
+        {
+            public function __construct(
+                public object $initData
+            )
+            {
+            }
+        };
+
+        $this->assertEquals([
+            'initData'  => [
+                'queryId' => null,
+                'user' => [
+                    'id' => null,
+                    'firstName' => 'Сергій'
+                ]
+            ]
+        ], $arrayable->toArray());
+
+        return $arrayable;
+    }
+
+    /**
+     * @depends testPropertyDeep
+     */
+    public function testAlien(object $object): void
+    {
+        $arrayable = new class extends Arrayable {};
+        $this->assertEquals([
+            'initData'  => [
+                'queryId' => null,
+                'user' => [
+                    'id' => null,
+                    'firstName' => 'Сергій'
+                ]
+            ]
+        ], $arrayable->toArray($object));
+    }
+}


### PR DESCRIPTION
- Each entity can be obtained as an array.
- If the entity contains properties with objects, they will also be processed throughout the depth.
- If no value is set for the property, it will default to null.
- Only public properties are aired.
- You can convert external objects
- stdClass does not contain public properties, so it is not supported