### PR TITLE
Receive an exception if the validation fails (#32)

### DIFF
--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace TgWebValid\Exceptions;
+
+use Exception;
+
+class ValidationException extends Exception
+{
+}

--- a/src/TgWebValid.php
+++ b/src/TgWebValid.php
@@ -10,23 +10,30 @@ use TgWebValid\Validator\LoginWidgetValidator;
 final class TgWebValid
 {
     public function __construct(
-        private string $token
+        private string $token,
+        private bool $throw = false
     )
     {
     }
 
-    public function validateInitData(string $initData): InitData|false
+    public function validateInitData(string $initData, ?bool $throw = null): InitData|false
     {
-        $validator = new InitDataValidator($this->token);
+        $validator = new InitDataValidator(
+            $this->token,
+            $throw ?? $this->throw
+        );
         return $validator->validate($initData);
     }
 
     /**
      * @param array<string, int|string|bool> $user
      */
-    public function validateLoginWidget(array $user): LoginWidget|false
+    public function validateLoginWidget(array $user, ?bool $throw = null): LoginWidget|false
     {
-        $validator = new LoginWidgetValidator($this->token);
+        $validator = new LoginWidgetValidator(
+            $this->token,
+            $throw ?? $this->throw
+        );
         return $validator->validate($user);
     }
 }

--- a/src/Validator/InitDataValidator.php
+++ b/src/Validator/InitDataValidator.php
@@ -3,6 +3,7 @@
 namespace TgWebValid\Validator;
 
 use TgWebValid\Entities\InitData;
+use TgWebValid\Exceptions\ValidationException;
 
 final class InitDataValidator extends Validator
 {
@@ -18,6 +19,9 @@ final class InitDataValidator extends Validator
         $hash    = hashInitData($data, $this->token);
 
         if (!$this->matchHash($hash, $initData->hash)) {
+            if ($this->throw) {
+                throw new ValidationException('Telegram InitData authentication error. Hash does not match.');
+            }
             return false;
         }
 

--- a/src/Validator/LoginWidgetValidator.php
+++ b/src/Validator/LoginWidgetValidator.php
@@ -3,6 +3,7 @@
 namespace TgWebValid\Validator;
 
 use TgWebValid\Entities\LoginWidget;
+use TgWebValid\Exceptions\ValidationException;
 
 final class LoginWidgetValidator extends Validator
 {
@@ -20,6 +21,9 @@ final class LoginWidgetValidator extends Validator
         $hash    = hashLoginWidget($data, $this->token);
 
         if (!$this->matchHash($hash, $user->hash)) {
+            if ($this->throw) {
+                throw new ValidationException('Telegram Login Widget authentication error. Hash does not match.');
+            }
             return false;
         }
 

--- a/src/Validator/Validator.php
+++ b/src/Validator/Validator.php
@@ -5,7 +5,8 @@ namespace TgWebValid\Validator;
 abstract class Validator
 {
     public function __construct(
-        protected string $token
+        protected string $token,
+        protected bool $throw = false
     )
     {
     }

--- a/tests/TgWebValidTest.php
+++ b/tests/TgWebValidTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace TgWebValid\Test;
+
+use PHPUnit\Framework\TestCase;
+use TgWebValid\Exceptions\ValidationException;
+use TgWebValid\TgWebValid;
+
+final class TgWebValidTest extends TestCase
+{
+    protected string $initData = 'query_id=AAE5gYJAAAAAADmBgkD7IagW&user=%7B%22id%22%3A1082294585%2C%22first_name%22%3A%22%D0%A1%D0%B5%D1%80%D0%B3%D1%96%D0%B9%22%2C%22last_name%22%3A%22%D0%97%D0%B0%D1%81%D0%B0%D0%B4%D0%B8%D0%BD%D1%81%D1%8C%D0%BA%D0%B8%D0%B9%22%2C%22username%22%3A%22CrazyTapokUA%22%2C%22language_code%22%3A%22uk%22%7D&auth_date=1684086610&hash=f0f336451c74fc794e2b0b9fcaf3e27e16ca74afbfd0958a8d21efd9e8e2b53c';
+
+    protected TgWebValid $validator;
+
+    public function setUp(): void
+    {
+        $this->validator = new TgWebValid('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4');
+    }
+
+    public function testGlobalExceptionInitData(): void
+    {
+        $validator = new TgWebValid('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4', true);
+
+        $this->expectException(ValidationException::class);
+        $validator->validateInitData($this->initData . '1');
+    }
+
+    public function testGlobalNoExceptionInitData(): void
+    {
+        $result = $this->validator->validateInitData($this->initData . '1');
+        $this->assertFalse($result);
+    }
+
+    public function testGlobalExceptionLoginWidget(): void
+    {
+        $validator = new TgWebValid('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4', true);
+
+        $this->expectException(ValidationException::class);
+        $validator->validateLoginWidget([
+            'auth_date' => 1679130118,
+            'first_name' => 'Сергій',
+            'hash' => 'e286fe20edabc0f086ba11bad5eead92a67776d01ac97e814ddfb683974d16e9',
+        ]);
+    }
+
+    public function testGlobalNoExceptionLoginWidget(): void
+    {
+        $result = $this->validator->validateLoginWidget([
+            'auth_date' => 1679130118,
+            'first_name' => 'Сергій',
+            'hash' => 'e286fe20edabc0f086ba11bad5eead92a67776d01ac97e814ddfb683974d16e9',
+        ]);
+        $this->assertFalse($result);
+    }
+
+    public function testLocalExceptionInitData(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validateInitData($this->initData . '1', true);
+    }
+
+    public function testLocalNoExceptionInitData(): void
+    {
+        $result = $this->validator->validateInitData($this->initData . '1', false);
+        $this->assertFalse($result);
+    }
+
+    public function testLocalExceptionLoginWidget(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validateLoginWidget([
+            'auth_date' => 1679130118,
+            'first_name' => 'Сергій',
+            'hash' => 'e286fe20edabc0f086ba11bad5eead92a67776d01ac97e814ddfb683974d16e9',
+        ], true);
+    }
+
+    public function testLocalNoExceptionLoginWidget(): void
+    {
+        $result = $this->validator->validateLoginWidget([
+            'auth_date' => 1679130118,
+            'first_name' => 'Сергій',
+            'hash' => 'e286fe20edabc0f086ba11bad5eead92a67776d01ac97e814ddfb683974d16e9',
+        ], false);
+        $this->assertFalse($result);
+    }
+
+    public function testChangeGlobalNoExceptionInitData(): void
+    {
+        $validator = new TgWebValid('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4', true);
+        $result = $validator->validateInitData($this->initData . '1', false);
+        $this->assertFalse($result);
+    }
+
+    public function testChangeGlobalNoExceptionLoginWidget(): void
+    {
+        $validator = new TgWebValid('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4', true);
+        $result = $validator->validateLoginWidget([
+            'auth_date' => 1679130118,
+            'first_name' => 'Сергій',
+            'hash' => 'e286fe20edabc0f086ba11bad5eead92a67776d01ac97e814ddfb683974d16e9',
+        ], false);
+        $this->assertFalse($result);
+    }
+}

--- a/tests/Validator/InitDataValidatorTest.php
+++ b/tests/Validator/InitDataValidatorTest.php
@@ -4,6 +4,7 @@ namespace TgWebValid\Test\Validator;
 
 use PHPUnit\Framework\TestCase;
 use TgWebValid\Entities\InitData;
+use TgWebValid\Exceptions\ValidationException;
 use TgWebValid\Validator\InitDataValidator;
 
 class InitDataValidatorTest extends TestCase
@@ -14,7 +15,7 @@ class InitDataValidatorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->validator = new InitDataValidator ('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4');
+        $this->validator = new InitDataValidator('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4');
     }
 
     public function testParse(): void
@@ -41,5 +42,23 @@ class InitDataValidatorTest extends TestCase
         $result = $this->validator->validate($this->initData . '1');
 
         $this->assertFalse($result);
+    }
+
+    public function testException(): void
+    {
+        $this->validator = new InitDataValidator('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4', true);
+
+        $this->expectException(ValidationException::class);
+
+        $this->validator->validate($this->initData . '1');
+    }
+
+    public function testNoException(): void
+    {
+        $this->validator = new InitDataValidator('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4', true);
+        
+        $result = $this->validator->validate($this->initData);
+
+        $this->assertInstanceOf(InitData::class, $result);
     }
 }

--- a/tests/Validator/LoginWidgetValidatorTest.php
+++ b/tests/Validator/LoginWidgetValidatorTest.php
@@ -4,6 +4,7 @@ namespace TgWebValid\Test\Validator;
 
 use PHPUnit\Framework\TestCase;
 use TgWebValid\Entities\LoginWidget;
+use TgWebValid\Exceptions\ValidationException;
 use TgWebValid\Validator\LoginWidgetValidator;
 
 class LoginWidgetValidatorTest extends TestCase
@@ -12,7 +13,7 @@ class LoginWidgetValidatorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->validator = new LoginWidgetValidator ('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4');
+        $this->validator = new LoginWidgetValidator('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4');
     }
 
     public function testValidated(): void
@@ -39,5 +40,35 @@ class LoginWidgetValidatorTest extends TestCase
         ]);
 
         $this->assertFalse($result);
+    }
+
+    public function testException(): void
+    {
+        $this->validator = new LoginWidgetValidator('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4', true);
+
+        $this->expectException(ValidationException::class);
+
+        $this->validator->validate([
+            'auth_date' => 1679130118,
+            'first_name' => 'Сергій',
+            'hash' => 'e286fe20edabc0f086ba11bad5eead92a67776d01ac97e814ddfb683974d16e9',
+        ]);
+    }
+
+    public function testNoException(): void
+    {
+        $this->validator = new LoginWidgetValidator('5854973744:AAFnq4HoybEzqCJ-8HYHY_zlvkc_-H-kXq4', true);
+
+        $result = $this->validator->validate([
+            'auth_date' => 1685117908,
+            'first_name' => 'Сергій',
+            'hash' => 'e286fe20edabc0f086ba11bad5eead92a67776d01ac97e814ddfb683974d16e9',
+            'id' => 1082294585,
+            'last_name' => 'Засадинський',
+            'photo_url' => 'https://t.me/i/userpic/320/7gMg9ZfoSzMQcLwYiEj4rLAofXXn0wOBV9HXGb6c1T0.jpg',
+            'username' => 'CrazyTapokUA'
+        ]);
+
+        $this->assertInstanceOf(LoginWidget::class, $result);
     }
 }


### PR DESCRIPTION
- Exceptions are enabled globally when creating TgWebValid.
- The exception is raised locally, separately for each check.
- Local settings have a higher priority, so they override global settings if necessary.