### PR TITLE
Allow to use Carbon version: "^2.67|^3.2"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require": {
         "php": "^8.2",
-        "nesbot/carbon": "^3.2"
+        "nesbot/carbon": "^2.67|^3.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
This pull request updates the `nesbot/carbon` dependency version in the `composer.json` file to support both version `^2.67` and `^3.2`. This change is necessary to ensure compatibility with packages that require either version of Carbon.