### PR TITLE
fix: correct argument order in hash_hmac for Mini App validation

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -39,7 +39,7 @@ if (!function_exists('hashInitData')) {
      */
     function hashInitData(string $data, string $token): string
     {
-        $secretKey = hash_hmac('sha256', $token, 'WebAppData', true);
+        $secretKey = hash_hmac('sha256', 'WebAppData', $token, true);
         return bin2hex(hash_hmac('sha256', $data, $secretKey, true));
     }
 }


### PR DESCRIPTION
### Description / Описание
**EN:** Fixed a critical bug in `hashInitData()` function where arguments for `hash_hmac()` were passed in the wrong order. According to PHP documentation, the signature is `hash_hmac($algo, $data, $key)`. In Telegram's Mini App documentation, the bot token must be used as a **key** and `'WebAppData'` as **data**. Currently, it's vice versa, which breaks Telegram Mini App validation.

### Links / Ссылки
* Telegram Docs: https://core.telegram.org/bots/webapps#validating-data-received-via-the-mini-app
* PHP Docs: https://www.php.net/manual/en/function.hash-hmac.php